### PR TITLE
replace pdftotext with PyPDF2 (extractText)

### DIFF
--- a/colrev/ops/built_in/pdf_prep/cover_page.py
+++ b/colrev/ops/built_in/pdf_prep/cover_page.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import shutil
-import subprocess
 import typing
 from dataclasses import dataclass
 from pathlib import Path
@@ -60,8 +59,7 @@ class PDFCoverPage(JsonSchemaMixin):
 
         def __get_coverpages(*, pdf: str) -> typing.List[int]:
             # pylint: disable=too-many-branches
-            # for corrupted PDFs pdftotext seems to be more robust than
-            # pdf_reader.getPage(0).extractText()
+
             coverpages: typing.List[int] = []
 
             try:
@@ -98,22 +96,12 @@ class PDFCoverPage(JsonSchemaMixin):
             if str(first_page_average_hash_16) in first_page_hashes:
                 coverpages.append(0)
 
-            res = subprocess.run(
-                ["/usr/bin/pdftotext", pdf, "-f", "1", "-l", "1", "-enc", "UTF-8", "-"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True,
-            )
+            res = pdf_reader.getPage(0).extractText()
             page0 = (
                 res.stdout.decode("utf-8").replace(" ", "").replace("\n", "").lower()
             )
 
-            res = subprocess.run(
-                ["/usr/bin/pdftotext", pdf, "-f", "2", "-l", "2", "-enc", "UTF-8", "-"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True,
-            )
+            res = pdf_reader.getPage(1).extractText()
             page1 = (
                 res.stdout.decode("utf-8").replace(" ", "").replace("\n", "").lower()
             )


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #126

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Poppler/pdftotext is replaced by PyPDF2 (extractText()). 
- Tests of extractText() did not raise many Exceptions.
- Remaining Exceptions may be fixed by the PyPDF2 project, which is quite active. This is preferred to the poppler dependency.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
